### PR TITLE
upgrade to scalaparse 0.2.1

### DIFF
--- a/api/src/main/scala/scalatex/stages/Parser.scala
+++ b/api/src/main/scala/scalatex/stages/Parser.scala
@@ -22,7 +22,7 @@ object Parser extends ((String, Int) => Ast.Block){
 
 }
 class Parser(indent: Int = 0, offset: Int = 0) {
-  import Scala.{KeyWordOperators => K}
+  import scalaparse.syntax.{Key => K}
 
   /**
    * Wraps another parser, succeeding/failing identically

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val api = project.settings(sharedSettings:_*)
     name := "scalatex-api",
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "utest" % "0.3.0" % "test",
-      "com.lihaoyi" %% "scalaparse" % "0.2.0",
+      "com.lihaoyi" %% "scalaparse" % "0.2.1",
       "com.lihaoyi" %% "scalatags" % "0.5.2",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ),


### PR DESCRIPTION
scalaparse 0.2.1 isn't binary compatible with 0.2.0, which is not nice at all :-(

This PR switches to it nevertheless.