### PR TITLE
Crashes in Highlighter.highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 target/
 *.iml
 .idea/
+
+# Eclipse project files
+.classpath
+.settings
+.project
+

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val site =
     "org.webjars" % "font-awesome" % "4.2.0",
     "com.lihaoyi" %% "scalatags" % "0.5.2",
     "org.webjars" % "pure" % "0.5.0",
-    "com.lihaoyi" %% "upickle" % "0.2.7"
+    "com.lihaoyi" %% "upickle" % "0.3.6"
   ),
   testFrameworks += new TestFramework("utest.runner.Framework"),
   (managedResources in Compile) += {

--- a/site/src/main/scala/scalatex/site/Highlighter.scala
+++ b/site/src/main/scala/scalatex/site/Highlighter.scala
@@ -110,9 +110,7 @@ trait Highlighter{ hl =>
       )
 
     }else{
-      val minIndent = lines.map(_.takeWhile(_ == ' ').length)
-        .filter(_ > 0)
-        .min
+      val minIndent = lines.map(_.takeWhile(_ == ' ').length).min
       val stripped = lines.map(_.drop(minIndent))
         .dropWhile(_ == "")
         .mkString("\n")

--- a/site/src/main/scala/scalatex/site/Sidebar.scala
+++ b/site/src/main/scala/scalatex/site/Sidebar.scala
@@ -7,7 +7,7 @@ import scalatags.Text.all._
 object Sidebar {
   def snippet(tree: Seq[Tree[String]]) = script(raw(s"""
     scalatex.scrollspy.Controller().main(
-      ${upickle.write(tree)}
+      ${upickle.default.write(tree)}
   )"""))
   def autoResources = Seq(root/'scalatex/'scrollspy/"scrollspy.js")
 }

--- a/site/src/test/scala/scalatex/site/Tests.scala
+++ b/site/src/test/scala/scalatex/site/Tests.scala
@@ -172,6 +172,26 @@ object Tests extends TestSuite{
             |)""".stripMargin
         assert(txt == expected)
       }
+      'indentation{
+        val lang = "js"
+        'noIndent{
+          // Shouldn't crash when no lines are indented
+          val text = "{\ntest\n}"
+          val expectedLines = text
+          val expected = pre(code(cls:=lang + " " + Styles.css.highlightMe.name, expectedLines))
+          val actual = hl.highlight(text, lang)
+          assert(actual == expected)
+        }
+        'zeroMinIndent{
+          // Shouldn't delete text if minimum indent is 0
+          val lang = "js"
+          val text = "{\n  test\n}"
+          val expectedLines = text
+          val expected = pre(code(cls:=lang + " " + Styles.css.highlightMe.name, expectedLines))
+          val actual = hl.highlight(text, lang)
+          assert(actual == expected)
+        }
+      }
     }
     'Site{
       'simple {


### PR DESCRIPTION
I am not sure what the purpose of the filter line is in `Highlighter.highlight` but it causes pretty scary bugs on very simple inputs, such as single line, non-indented text, e.g.:

    case class X(a: Int)

or simple JSON, e.g.:

    {
      "test" : 123
    }

In the latter case the line with the opening brace disappears, and the former causes a crash due to an attempt to find the minimum of an empty list.

Also fixes #18 