### PR TITLE
normalize absolute paths to use forward slashes; fixes Windows build

### DIFF
--- a/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
+++ b/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
@@ -102,7 +102,7 @@ object ScalatexReadme{
           object Main extends scalatex.site.Main(
             url = "$url",
             wd = ammonite.ops.Path("${fixPath(wd)}"),
-            output = ammonite.ops.Path("${((target in Compile).value / "scalatex").getAbsolutePath}"),
+            output = ammonite.ops.Path("${fixPath((target in Compile).value / "scalatex")}"),
             extraAutoResources = Seq[String]($autoResourcesStrings).map(ammonite.ops.root/ammonite.ops.RelPath(_)),
             extraManualResources = Seq[String]($manualResourceStrings).map(ammonite.ops.root/ammonite.ops.RelPath(_)),
             scalatex.$source()


### PR DESCRIPTION
Theses changes permit Scalatex to build on Windows.  My eventual goal is to get Ammonite working on Windows, but this is step one.

This is my first pull request on github, so please let me know if I have violated any protocols.
It builds, and line lengths are < 80, and it passes all tests in the following build environments:

* Windows 10 / sbt.bat
* cygwin64 (on Windows 10)
* Linux Ubuntu x64

Thanks for an interesting project!
