### PR TITLE
Configure for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Adapted from https://github.com/sbt/sbt-native-packager/blob/master/appveyor.yml
+version: '{build}'
+os: Windows Server 2012
+
+#  To make the extended ascii characters work on Windows
+#  we need to set string encoding for jvm to utf-8 on windows
+environment:
+  SBT_OPTS: -Dfile.encoding=UTF8
+  JAVA_OPTS: -Dfile.encoding=UTF8
+install:
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\sbt" )) {
+        (new-object System.Net.WebClient).DownloadFile(
+          'https://dl.bintray.com/sbt/native-packages/sbt/0.13.8/sbt-0.13.8.zip',
+          'C:\sbt-bin.zip'
+        )
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\sbt-bin.zip", "C:\sbt")
+      }
+  - cmd: SET PATH=C:\sbt\sbt\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
+
+build_script:
+  - sbt clean compile
+test_script:
+  - sbt test
+

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
-# Scalatex [![Build Status](https://travis-ci.org/lihaoyi/Scalatex.svg?branch=master)](https://travis-ci.org/lihaoyi/Scalatex)
+# Scalatex [![Build Status][travis-badge]][travis-link] [![Build (Windows)][appveyor-badge]][appveyor-link]
 [Documentation](http://lihaoyi.github.io/Scalatex)
 
+[travis-badge]: https://travis-ci.org/lihaoyi/Scalatex.svg?branch=master
+[travis-link]: https://travis-ci.org/lihaoyi/Scalatex
+[appveyor-badge]: https://ci.appveyor.com/api/projects/status/github/lihaoyi/Scalatex
+[appveyor-link]: https://ci.appveyor.com/project/lihaoyi/ammonite


### PR DESCRIPTION
Adding AppVeyor to test Scalatex in Windows. This is a stepping stone to build Ammonite in Windows.