### PR TITLE
Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: scala
 # ignored, because if we do the ++ thing it uses the wrong
 # scalaVersion to compile the sbt plugin which blows up
 scala:
-- 2.11.6
+- 2.12.1
 script:
 - sbt test "readme/run --validate"
 jdk:
-- oraclejdk7
 - oraclejdk8
 sudo: false

--- a/api/src/test/scala-2.11/scalatex/Scala211ErrorTests.scala
+++ b/api/src/test/scala-2.11/scalatex/Scala211ErrorTests.scala
@@ -1,0 +1,56 @@
+package scalatex
+
+import utest._
+import scalatex.stages._
+import scalatags.Text.all._
+import scalatex.Internals.{DebugFailure, twRuntimeErrors, twfRuntimeErrors}
+import ErrorTests.check
+
+object Scala211ErrorTests extends TestSuite {
+  val tests = TestSuite {
+    'chained {
+      'curlies {
+        * - check(
+          twRuntimeErrors("@p{@Seq(1, 2, 3).foldLeft(0)}"),
+          "missing argument list for method foldLeft",
+          """
+          twRuntimeErrors("@p{@Seq(1, 2, 3).foldLeft(0)}"),
+                                                    ^
+          """
+        )
+        * - check(
+          twRuntimeErrors("@Nil.map{ @omg}"),
+          "too many arguments for method map",
+          """
+          twRuntimeErrors("@Nil.map{ @omg}"),
+                                   ^
+          """
+        )
+      }
+    }
+    'ifElse {
+      'oneLine {
+        * - check(
+          twRuntimeErrors("@if(true){ * 10  }else{ @math.sin(3, 4, 5) }"),
+          "too many arguments for method sin: (x: Double)Double",
+          """
+          twRuntimeErrors("@if(true){ * 10  }else{ @math.sin(3, 4, 5) }"),
+                                                            ^
+          """
+        )
+      }
+    }
+    'forLoop {
+      'oneLine {
+        'body - check(
+          twRuntimeErrors("omg @for(x <- 0 until 10){ @((x, 2) + (1, 2)) }"),
+          """too many arguments for method +""",
+          """
+          twRuntimeErrors("omg @for(x <- 0 until 10){ @((x, 2) + (1, 2)) }"),
+                                                               ^
+          """
+        )
+      }
+    }
+  }
+}

--- a/api/src/test/scala-2.12/scalatex/Scala212ErrorTests.scala
+++ b/api/src/test/scala-2.12/scalatex/Scala212ErrorTests.scala
@@ -1,0 +1,56 @@
+package scalatex
+
+import utest._
+import scalatex.stages._
+import scalatags.Text.all._
+import scalatex.Internals.{DebugFailure, twRuntimeErrors, twfRuntimeErrors}
+import ErrorTests.check
+
+object Scala212ErrorTests extends TestSuite {
+  val tests = TestSuite {
+    'chained {
+      'curlies {
+        * - check(
+          twRuntimeErrors("@p{@Seq(1, 2, 3).foldLeft(0)}"),
+          "type mismatch",
+          """
+          twRuntimeErrors("@p{@Seq(1, 2, 3).foldLeft(0)}"),
+                                                    ^
+          """
+        )
+        * - check(
+          twRuntimeErrors("@Nil.map{ @omg}"),
+          "too many arguments (2) for method map: ",
+          """
+          twRuntimeErrors("@Nil.map{ @omg}"),
+                                      ^
+          """
+        )
+      }
+    }
+    'ifElse {
+      'oneLine {
+        * - check(
+          twRuntimeErrors("@if(true){ * 10  }else{ @math.sin(3, 4, 5) }"),
+          "too many arguments (3) for method sin: (x: Double)Double",
+          """
+          twRuntimeErrors("@if(true){ * 10  }else{ @math.sin(3, 4, 5) }"),
+                                                                ^
+          """
+        )
+      }
+    }
+    'forLoop {
+      'oneLine {
+        'body - check(
+          twRuntimeErrors("omg @for(x <- 0 until 10){ @((x, 2) + (1, 2)) }"),
+          """too many arguments (2) for method +: (other: String)String""",
+          """
+          twRuntimeErrors("omg @for(x <- 0 until 10){ @((x, 2) + (1, 2)) }"),
+                                                                     ^
+          """
+        )
+      }
+    }
+  }
+}

--- a/api/src/test/scala/scalatex/ErrorTests.scala
+++ b/api/src/test/scala/scalatex/ErrorTests.scala
@@ -203,38 +203,19 @@ object ErrorTests extends TestSuite{
       }
       'curlies{
         * - check(
-          twRuntimeErrors("@p{@Seq(1, 2, 3).foldLeft(0)}"),
-          "missing arguments for method foldLeft",
-          """
-          twRuntimeErrors("@p{@Seq(1, 2, 3).foldLeft(0)}"),
-                                                    ^
-          """
-        )
-
-        * - check(
           twRuntimeErrors("@Nil.foldLeft{XY}"),
-          "missing arguments for method foldLeft",
+          "missing argument list for method foldLeft",
           """
           twRuntimeErrors("@Nil.foldLeft{XY}"),
                                         ^
           """
         )
-
-
         * - check(
           twRuntimeErrors("@Seq(1).map{(y: String) => omg}"),
             "type mismatch",
             """
           twRuntimeErrors("@Seq(1).map{(y: String) => omg}"),
                                       ^
-          """
-        )
-        * - check(
-          twRuntimeErrors("@Nil.map{ @omg}"),
-          "too many arguments for method map",
-          """
-          twRuntimeErrors("@Nil.map{ @omg}"),
-                                   ^
           """
         )
       }
@@ -275,14 +256,6 @@ object ErrorTests extends TestSuite{
           """
           twRuntimeErrors("@if(true){ (@math.pow(10)) * 10  }else{ 2 }"),
                                                 ^
-          """
-        )
-        * - check(
-          twRuntimeErrors("@if(true){ * 10  }else{ @math.sin(3, 4, 5) }"),
-          "too many arguments for method sin: (x: Double)Double",
-          """
-          twRuntimeErrors("@if(true){ * 10  }else{ @math.sin(3, 4, 5) }"),
-                                                            ^
           """
         )
       }
@@ -345,15 +318,6 @@ object ErrorTests extends TestSuite{
           """
           twRuntimeErrors("omg @for(x <- (0 + 1 + 2) omglolol (10 + 11 + 2)){ hello }"),
                                                      ^
-          """
-        )
-
-        'body - check(
-          twRuntimeErrors("omg @for(x <- 0 until 10){ @((x, 2) + (1, 2)) }"),
-          """too many arguments for method +""",
-          """
-          twRuntimeErrors("omg @for(x <- 0 until 10){ @((x, 2) + (1, 2)) }"),
-                                                               ^
           """
         )
       }

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val site =
   name := "scalatex-site",
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "utest" % "0.4.4" % "test",
-    "com.lihaoyi" %% "ammonite-ops" % "0.8.0",
+    "com.lihaoyi" %% "ammonite-ops" % "0.8.1",
     "org.webjars" % "highlightjs" % "9.7.0",
     "org.webjars" % "font-awesome" % "4.7.0",
     "com.lihaoyi" %% "scalatags" % Version.scalaTags,

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val Version = new {
 val sharedSettings = Seq(
   version := _root_.scalatex.Constants.version,
   organization := "com.lihaoyi",
-  crossScalaVersions:= Seq("2.10.4", "2.11.8"),
-  scalaVersion := "2.11.8",
+  crossScalaVersions:= Seq("2.11.8", "2.12.1"),
+  scalaVersion := "2.12.1",
   libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.5" % "provided",
   addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.5"),
   autoCompilerPlugins := true,
@@ -54,7 +54,7 @@ lazy val api = project.settings(sharedSettings:_*)
 lazy val scalatexSbtPlugin = project.settings(sharedSettings:_*)
   .settings(
   name := "scalatex-sbt-plugin",
-  scalaVersion := "2.10.4",
+  scalaVersion := "2.10.6",
   sbtPlugin := true,
   (unmanagedSources in Compile) += baseDirectory.value/".."/"project"/"Constants.scala"
 )
@@ -89,7 +89,8 @@ lazy val site =
 lazy val scrollspy = project
   .enablePlugins(ScalaJSPlugin)
   .settings(
-    scalaVersion := "2.11.6",
+    scalaVersion := "2.12.1",
+    crossScalaVersions:= Seq("2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.lihaoyi" %%% "upickle" % Version.upickle,
       "org.scala-js" %%% "scalajs-dom" % "0.9.1",

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val site =
     "org.webjars" % "highlightjs" % "9.7.0",
     "org.webjars" % "font-awesome" % "4.7.0",
     "com.lihaoyi" %% "scalatags" % Version.scalaTags,
-    "org.webjars" % "pure" % "2.83",
+    "org.webjars" % "pure" % "0.6.0",
     "com.lihaoyi" %% "upickle" % Version.upickle,
     "org.scalaj" %% "scalaj-http" % "2.3.0"
   ),

--- a/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
+++ b/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
@@ -103,8 +103,8 @@ object ScalatexReadme{
             url = "$url",
             wd = ammonite.ops.Path("${fixPath(wd)}"),
             output = ammonite.ops.Path("${fixPath((target in Compile).value / "scalatex")}"),
-            extraAutoResources = Seq[String]($autoResourcesStrings).map(ammonite.ops.root/ammonite.ops.RelPath(_)),
-            extraManualResources = Seq[String]($manualResourceStrings).map(ammonite.ops.root/ammonite.ops.RelPath(_)),
+            extraAutoResources = Seq[String]($autoResourcesStrings).map(ammonite.ops.resource/ammonite.ops.RelPath(_)),
+            extraManualResources = Seq[String]($manualResourceStrings).map(ammonite.ops.resource/ammonite.ops.RelPath(_)),
             scalatex.$source()
           )
         """)

--- a/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
+++ b/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
@@ -47,7 +47,7 @@ object SbtPlugin extends sbt.AutoPlugin {
   )
   override val projectSettings = inConfig(Test)(mySeq) ++ inConfig(Compile)(mySeq) ++ Seq(
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "scalatex-api" % scalatexVersion, "com.lihaoyi" %% "scalatags" % "0.5.3"
+      "com.lihaoyi" %% "scalatex-api" % scalatexVersion
     ),
     watchSources ++= {
       for{
@@ -112,7 +112,7 @@ object ScalatexReadme{
       },
       (SbtPlugin.scalatexDirectory in Compile) := file(projectId),
       libraryDependencies += "com.lihaoyi" %% "scalatex-site" % SbtPlugin.scalatexVersion,
-      scalaVersion := "2.11.6"
+      scalaVersion := "2.12.1"
     )
   ).enablePlugins(SbtPlugin)
 }

--- a/site/src/main/scala/scalatex/site/Highlighter.scala
+++ b/site/src/main/scala/scalatex/site/Highlighter.scala
@@ -12,7 +12,7 @@ import ammonite.ops._
 trait Highlighter{ hl =>
   val languages = mutable.Set.empty[String]
   def webjars = root/"META-INF"/'resources/'webjars
-  def highlightJs = webjars/'highlightjs/"8.2-1"
+  def highlightJs = webjars/'highlightjs/"9.7.0"
   def style: String = "idea"
 
   case class lang(name: String){

--- a/site/src/main/scala/scalatex/site/Highlighter.scala
+++ b/site/src/main/scala/scalatex/site/Highlighter.scala
@@ -11,7 +11,7 @@ import ammonite.ops._
  */
 trait Highlighter{ hl =>
   val languages = mutable.Set.empty[String]
-  def webjars = root/"META-INF"/'resources/'webjars
+  def webjars = resource/"META-INF"/'resources/'webjars
   def highlightJs = webjars/'highlightjs/"9.7.0"
   def style: String = "idea"
 
@@ -132,7 +132,7 @@ trait Highlighter{ hl =>
    *                  [[suffixMappings]]
    */
   def ref[S: RefPath, V: RefPath]
-         (filePath: ammonite.ops.FilePath,
+         (filePath: ammonite.ops.BasePath,
           start: S = Nil,
           end: V = Nil,
           className: String = null) = {

--- a/site/src/main/scala/scalatex/site/Main.scala
+++ b/site/src/main/scala/scalatex/site/Main.scala
@@ -2,10 +2,11 @@ package scalatex.site
 
 import java.util.concurrent.Executors
 
-import ammonite.ops.{cwd, RelPath, Path}
+import ammonite.ops.{Path, ResourcePath}
+
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future, ExecutionContext}
-import scala.util.{Success, Failure, Try}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 import scalaj.http._
 import scalatags.Text.all._
 import scalatex.site
@@ -21,8 +22,8 @@ import scalatex.site
 class Main(url: String,
            val wd: Path,
            output: Path,
-           extraAutoResources: Seq[Path],
-           extraManualResources: Seq[Path],
+           extraAutoResources: Seq[ResourcePath],
+           extraManualResources: Seq[ResourcePath],
            frag: => Frag) extends scalatex.site.Site{
 
   lazy val hl = new Highlighter {

--- a/site/src/main/scala/scalatex/site/Sidebar.scala
+++ b/site/src/main/scala/scalatex/site/Sidebar.scala
@@ -9,5 +9,5 @@ object Sidebar {
     scalatex.scrollspy.Controller().main(
       ${upickle.default.write(tree)}
   )"""))
-  def autoResources = Seq(root/'scalatex/'scrollspy/"scrollspy.js")
+  def autoResources = Seq(resource/'scalatex/'scrollspy/"scrollspy.js")
 }

--- a/site/src/main/scala/scalatex/site/Site.scala
+++ b/site/src/main/scala/scalatex/site/Site.scala
@@ -16,13 +16,13 @@ trait Site{
 
   def webjars = root/"META-INF"/'resources/'webjars
 
-  def fontAwesome = webjars/"font-awesome"/"4.2.0"
+  def fontAwesome = webjars/"font-awesome"/"4.7.0"
 
   /**
    * Resources related to the pure-css library
    */
   def pureCss = Seq(
-    webjars/'pure/"0.5.0"/"pure-min.css"
+    webjars/'pure/"0.6.0"/"pure-min.css"
   )
   /**
    * Resources related to the font awesome library
@@ -65,7 +65,7 @@ trait Site{
    * The header of this site's HTML page
    */
   def defaultHeader: Seq[Frag] = Seq(
-    link(href:="META-INF/resources/webjars/font-awesome/4.2.0/css/font-awesome.min.css", rel:="stylesheet"),
+    link(href:="META-INF/resources/webjars/font-awesome/4.7.0/css/font-awesome.min.css", rel:="stylesheet"),
     link(href:=stylesName, rel:="stylesheet"),
     link(rel:="shortcut icon", `type`:="image/png", href:="favicon.png"),
     meta(httpEquiv:="Content-Type", attrs.content:="text/html; charset=UTF-8"),

--- a/site/src/main/scala/scalatex/site/Site.scala
+++ b/site/src/main/scala/scalatex/site/Site.scala
@@ -6,6 +6,7 @@ import ammonite.ops.{Path, _}
 
 import scalatags.Text.all._
 import scalatags.Text.{attrs, tags2}
+
 /**
  * A semi-abstract trait that encapsulates everything necessary to generate
  * a Scalatex site. Only `content` is left abstract (and needs to be filled
@@ -14,7 +15,7 @@ import scalatags.Text.{attrs, tags2}
  */
 trait Site{
 
-  def webjars = root/"META-INF"/'resources/'webjars
+  def webjars = resource/"META-INF"/'resources/'webjars
 
   def fontAwesome = webjars/"font-awesome"/"4.7.0"
 
@@ -39,7 +40,7 @@ trait Site{
    * Resources custom-provided for this particular site
    */
   def siteCss = Set(
-    root/'scalatex/'site/"styles.css"
+    resource/'scalatex/'site/"styles.css"
   )
 
   /**
@@ -98,7 +99,7 @@ trait Site{
     }
 
     for(res <- manualResources) {
-      read.bytes! res |> write.over! outputRoot/(res relativeTo root)
+      read.bytes! res |> write.over! outputRoot/(res relativeTo resource)
     }
   }
 


### PR DESCRIPTION
Changes made in this PR:
-  pure webjar is downgraded. Because it looks like 2.83 is a [different library](https://github.com/pure/pure) 
- changes related to ammonite-ops reflect the changes made [here](https://github.com/lihaoyi/Ammonite/commit/fe29bc906ad2f931f0fdfe673afe53e8b2dfd762)
- scala 2.10 is removed, as compilation of scalatex-api failed. (I doubt it was ever compiled before)
- some of the test in ErrorTests are separated for 2.11 and 2.12,  as the style of error messages has been changed in 2.12.
