### PR TITLE
Add scala-js plugin to project site

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val scalatexSbtPlugin = project.settings(sharedSettings:_*)
 
 lazy val site =
   project
+    .enablePlugins(ScalaJSPlugin)
     .dependsOn(api)
     .settings(scalatex.SbtPlugin.projectSettings:_*)
     .settings(sharedSettings:_*)


### PR DESCRIPTION
To render usable the site properties through a scala-js website, the ScalaJSPlugin has been added to the site project.