### PR TITLE
Upgrade fastparse to 0.4.3.

### DIFF
--- a/api/src/test/scala/scalatex/ParseErrors.scala
+++ b/api/src/test/scala/scalatex/ParseErrors.scala
@@ -23,12 +23,12 @@ object ParseErrors extends TestSuite{
     * - check(
       """@{)
         |""".stripMargin,
-      """ (";" | Newline.rep(1) | "}" | `case`):1:3 ...")\n" """
+      """ (";" | Newline.rep(1) | "}"):1:3 ...")\n" """
     )
     * - check(
       """@({
         |""".stripMargin,
-      """ (";" | Newline.rep(1) | "}" | `case`):2:1 ..."" """
+      """ (";" | Newline.rep(1) | "}"):2:1 ..."" """
     )
     * - check(
       """@for{;
@@ -38,7 +38,7 @@ object ParseErrors extends TestSuite{
     * - check(
       """@{ => x
         |""".stripMargin,
-      """ (";" | Newline.rep(1) | "}" | `case`):1:4 ..."=> x\n" """
+      """ (";" | Newline.rep(1) | "}"):1:4 ..."=> x\n" """
     )
 
     * - check(

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val api = project.settings(sharedSettings:_*)
     name := "scalatex-api",
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "utest" % "0.4.4" % "test",
-      "com.lihaoyi" %% "scalaparse" % "0.4.2",
+      "com.lihaoyi" %% "scalaparse" % "0.4.3",
       "com.lihaoyi" %% "scalatags" % Version.scalaTags,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ),


### PR DESCRIPTION
We hit on binary compat issues in our scalatex readme while upgrade to fastparse 0.4.3 in scalameta

```
[error] /Users/ollie/dev/scalameta/readme/target/scala-2.11/src_managed/main/scalatex/Readme.scala:7: exception during macro expansion:
[error] java.lang.NoSuchMethodError: fastparse.all$.CharsWhile$default$2()I
```