### PR TITLE
Port build to sbt 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 # ignored, because if we do the ++ thing it uses the wrong
 # scalaVersion to compile the sbt plugin which blows up
 scala:
-- 2.12.1
+- 2.12.3
 script:
 - sbt test "readme/run --validate"
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -97,8 +97,9 @@ lazy val site =
 lazy val scrollspy = project
   .enablePlugins(ScalaJSPlugin)
   .settings(
-    scalaVersion := "2.12.1",
-    crossScalaVersions:= Seq("2.11.8", "2.12.1"),
+    scalaVersion := Constants.scala212,
+    crossScalaVersions:= Seq(Constants.scala211, Constants.scala212),
+    scalacOptions += "-P:scalajs:suppressExportDeprecations", // see https://github.com/scala-js/scala-js/issues/3092
     libraryDependencies ++= Seq(
       "com.lihaoyi" %%% "upickle" % Version.upickle,
       "org.scala-js" %%% "scalajs-dom" % "0.9.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,12 @@
+lazy val Constants = _root_.scalatex.Constants
 sharedSettings
 noPublish
 
-lazy val Version = new {
-  def scalaTags = "0.6.2"
-  def upickle = "0.4.4"
-  def scala210 = "2.10.6"
-  def scala211 = "2.11.11"
-  def scala212 = "2.12.2"
-}
-
-
 lazy val sharedSettings = Seq(
-  version := _root_.scalatex.Constants.version,
+  version := Constants.version,
   organization := "com.lihaoyi",
-  crossScalaVersions:= Seq(Version.scala211, Version.scala212),
-  scalaVersion := Version.scala212,
+  crossScalaVersions:= Seq(Constants.scala211, Constants.scala212),
+  scalaVersion := Constants.scala212,
   libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.5" % "provided",
   addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.5"),
   autoCompilerPlugins := true,
@@ -52,7 +44,7 @@ lazy val api = project.settings(sharedSettings:_*)
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "utest" % "0.4.8" % "test",
       "com.lihaoyi" %% "scalaparse" % "0.4.3",
-      "com.lihaoyi" %% "scalatags" % Version.scalaTags,
+      "com.lihaoyi" %% "scalatags" % Constants.scalaTags,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ),
     testFrameworks += new TestFramework("utest.runner.Framework")
@@ -61,8 +53,14 @@ lazy val api = project.settings(sharedSettings:_*)
 lazy val scalatexSbtPlugin = project.settings(sharedSettings:_*)
   .settings(
   name := "scalatex-sbt-plugin",
-  scalaVersion := Version.scala210,
-  crossScalaVersions := List(Version.scala210),
+  scalaVersion := {
+    if (sbtVersion.in(pluginCrossBuild).value.startsWith("0.13")) Constants.scala210
+    else Constants.scala212
+  },
+  // scalatexSbtPlugin/publish uses sbt 1.0 by default. To publish for 0.13, run
+  // ^^ 0.13.16 # similar as ++2.12.3 but for sbtVersion instead.
+  // scalatexSbtPlugin/publish
+  crossSbtVersions := List("1.0.0", "0.13.16"),
   sbtPlugin := true,
   (unmanagedSources in Compile) += baseDirectory.value/".."/"project"/"Constants.scala"
 )
@@ -80,9 +78,9 @@ lazy val site =
     "com.lihaoyi" %% "ammonite-ops" % "0.8.1",
     "org.webjars" % "highlightjs" % "9.7.0",
     "org.webjars" % "font-awesome" % "4.7.0",
-    "com.lihaoyi" %% "scalatags" % Version.scalaTags,
+    "com.lihaoyi" %% "scalatags" % Constants.scalaTags,
     "org.webjars" % "pure" % "0.6.0",
-    "com.lihaoyi" %% "upickle" % Version.upickle,
+    "com.lihaoyi" %% "upickle" % Constants.upickle,
     "org.scalaj" %% "scalaj-http" % "2.3.0"
   ),
   testFrameworks += new TestFramework("utest.runner.Framework"),
@@ -101,9 +99,9 @@ lazy val scrollspy = project
     crossScalaVersions:= Seq(Constants.scala211, Constants.scala212),
     scalacOptions += "-P:scalajs:suppressExportDeprecations", // see https://github.com/scala-js/scala-js/issues/3092
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %%% "upickle" % Version.upickle,
+      "com.lihaoyi" %%% "upickle" % Constants.upickle,
       "org.scala-js" %%% "scalajs-dom" % "0.9.1",
-      "com.lihaoyi" %%% "scalatags" % Version.scalaTags
+      "com.lihaoyi" %%% "scalatags" % Constants.scalaTags
     ),
     emitSourceMaps := false,
     noPublish

--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,4 +1,9 @@
 package scalatex
-package object Constants{
+object Constants{
+  val scalaTags = "0.6.2"
+  val upickle = "0.4.4"
+  val scala210 = "2.10.6"
+  val scala211 = "2.11.11"
+  val scala212 = "2.12.3"
   val version = "0.3.9"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-
-sbt.version=0.13.13
+sbt.version=1.0.0

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,11 +1,16 @@
 unmanagedSources in Compile ++= {
   val root = baseDirectory.value.getParentFile
-  (root / "scalatexSbtPlugin" ** "*.scala").get
+  val exclude = Map(
+    "0.13" -> "1.0",
+    "1.0" -> "0.13"
+  ).apply(sbtBinaryVersion.value)
+  (root / "scalatexSbtPlugin")
+    .descendantsExcept("*.scala", s"*sbt-$exclude*")
+    .get
 }
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")
-
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")

--- a/scalatexSbtPlugin/src/main/scala-sbt-0.13/scalatex/PluginCompat.scala
+++ b/scalatexSbtPlugin/src/main/scala-sbt-0.13/scalatex/PluginCompat.scala
@@ -1,0 +1,4 @@
+package scalatex
+
+object PluginCompat {
+}

--- a/scalatexSbtPlugin/src/main/scala-sbt-1.0/scalatex/PluginCompat.scala
+++ b/scalatexSbtPlugin/src/main/scala-sbt-1.0/scalatex/PluginCompat.scala
@@ -1,0 +1,8 @@
+package scalatex
+
+import sbt._
+import sbt.internal.io.Source
+object PluginCompat {
+  implicit def fileToInternalSource(file: File): Source =
+    new Source(file, AllPassFilter, NothingFilter)
+}

--- a/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
+++ b/scalatexSbtPlugin/src/main/scala/scalatex/SbtPlugin.scala
@@ -2,6 +2,8 @@ package scalatex
 
 import sbt.Keys._
 import sbt._
+import PluginCompat._
+
 object SbtPlugin extends sbt.AutoPlugin {
   val scalatexVersion = scalatex.Constants.version
   val scalatexDirectory = taskKey[sbt.File]("Clone stuff from github")
@@ -50,9 +52,10 @@ object SbtPlugin extends sbt.AutoPlugin {
       "com.lihaoyi" %% "scalatex-api" % scalatexVersion
     ),
     watchSources ++= {
+      val compileTarget = (target in Compile).value
       for{
         f <- (scalatexDirectory in Compile).value.get
-        if f.relativeTo((target in Compile).value).isEmpty
+        if f.relativeTo(compileTarget).isEmpty
       } yield f
     }
   )
@@ -79,10 +82,8 @@ object ScalatexReadme{
             wd: java.io.File,
             source: String,
             url: String,
-            autoResources: Seq[String] = Nil) = Project(
-    id = projectId,
-    base = file(projectId),
-    settings = scalatex.SbtPlugin.projectSettings ++ Seq(
+            autoResources: Seq[String] = Nil) =
+    Project(id = projectId, base = file(projectId)).settings(
       resourceDirectory in Compile := file(projectId) / "resources",
       sourceGenerators in Compile += task{
         val dir = (sourceManaged in Compile).value
@@ -112,7 +113,6 @@ object ScalatexReadme{
       },
       (SbtPlugin.scalatexDirectory in Compile) := file(projectId),
       libraryDependencies += "com.lihaoyi" %% "scalatex-site" % SbtPlugin.scalatexVersion,
-      scalaVersion := "2.12.1"
-    )
-  ).enablePlugins(SbtPlugin)
+      scalaVersion := _root_.scalatex.Constants.scala212
+    ).enablePlugins(SbtPlugin)
 }


### PR DESCRIPTION
scalatex is one of the last sbt plugins blocking scalafix and scalameta from moving to sbt 1.0, https://github.com/scalacenter/scalafix/issues/281. This PR complicates a bit the publish step for the sbt plugin in 0.13, see instructions in build.sbt. We can keep the build in 0.13.15 if that's preferred.