### PR TITLE
Release 0.3.11.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,10 +19,6 @@ lazy val sharedSettings = Seq(
           <url>http://www.opensource.org/licenses/mit-license.php</url>
         </license>
       </licenses>
-      <scm>
-        <url>git://github.com/lihaoyi/Scalatex.git</url>
-        <connection>scm:git://github.com/lihaoyi/Scalatex.git</connection>
-      </scm>
       <developers>
         <developer>
           <id>lihaoyi</id>
@@ -57,6 +53,7 @@ lazy val scalatexSbtPlugin = project.settings(sharedSettings:_*)
     if (sbtVersion.in(pluginCrossBuild).value.startsWith("0.13")) Constants.scala210
     else Constants.scala212
   },
+  crossScalaVersions := List(Constants.scala212),
   // scalatexSbtPlugin/publish uses sbt 1.0 by default. To publish for 0.13, run
   // ^^ 0.13.16 # similar as ++2.12.3 but for sbtVersion instead.
   // scalatexSbtPlugin/publish
@@ -95,6 +92,7 @@ lazy val site =
 lazy val scrollspy = project
   .enablePlugins(ScalaJSPlugin)
   .settings(
+    sharedSettings,
     scalaVersion := Constants.scala212,
     crossScalaVersions:= Seq(Constants.scala211, Constants.scala212),
     scalacOptions += "-P:scalajs:suppressExportDeprecations", // see https://github.com/scala-js/scala-js/issues/3092
@@ -114,6 +112,7 @@ lazy val readme = scalatex.ScalatexReadme(
   source = "Readme"
 )
 .settings(
+  sharedSettings,
   siteSourceDirectory := target.value / "scalatex",
   git.remoteRepo := "git@github.com:lihaoyi/scalatex.git",
   libraryDependencies := libraryDependencies.value.filter(_.name == "scalatex-site"),

--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,9 +1,9 @@
 package scalatex
 object Constants{
+  val version = "0.3.11"
   val scalaTags = "0.6.2"
   val upickle = "0.4.4"
   val scala210 = "2.10.6"
   val scala211 = "2.11.11"
   val scala212 = "2.12.3"
-  val version = "0.3.9"
 }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -590,6 +590,10 @@
       The limitations are not fundamental, but purely a matter of how Scalatex is being used now: static documents, rather than dynamic pages. If there's interest removing them would not be hard.
 
 @sect{Changelog}
+  @sect{0.3.11}
+    @ul
+      @li
+        sbt 1.0 support for scalatex-sbt-plugin.
   @sect{0.3.9}
     @ul
       @li


### PR DESCRIPTION
- Make build `+test` friendly.  sbt 1.0 `+` uses the sbt-doge `very` semantics.
- Remove scm info and add explicit depedency on sbt-git.
  Fixes "Duplicate scm" errors from sonatype encountered while publishing,
  explained here
  https://github.com/lihaoyi/Scalatex/pull/60#issuecomment-322054013.
  sbt-git is pulled in transitively via sbt-ghpages, a recent release of
  sbt-git added a feature where scmInfo is automatically populated, see
  https://github.com/sbt/sbt-git/pull/117#issuecomment-322060451
- I skipped 0.3.10 because of a `java.io.IOException: destination
  file exists and overwrite == false` error. I don't know where the
  destination file is, I've removed ~/.ivy2/local cache, target, ~/.m2 and
  the error still appears.