### PR TITLE
Update utest to 0.6.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val api = project.settings(sharedSettings:_*)
   .settings(
     name := "scalatex-api",
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "utest" % "0.4.8" % "test",
+      "com.lihaoyi" %% "utest" % "0.6.6" % "test",
       "com.lihaoyi" %% "scalaparse" % "1.0.0",
       "com.lihaoyi" %% "scalatags" % Constants.scalaTags,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
@@ -102,7 +102,7 @@ lazy val site =
   libraryDependencies := libraryDependencies.value.filter(!_.toString.contains("scalatex-api")),
   name := "scalatex-site",
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %% "utest" % "0.4.4" % "test",
+    "com.lihaoyi" %% "utest" % "0.6.6" % "test",
     "com.lihaoyi" %% "ammonite-ops" % "0.8.1",
     "org.webjars.bower" % "highlightjs" % "9.12.0",
     "org.webjars.bowergithub.highlightjs" % "highlight.js" % "9.12.0", 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.4
+sbt.version=1.2.6


### PR DESCRIPTION
I believe utest 0.6.x is not binary compatible with 0.4.x so this might warrant a minor version bump.